### PR TITLE
lightctl to change proportionally and volumectl to track the currently playing sink

### DIFF
--- a/lightctl
+++ b/lightctl
@@ -7,12 +7,17 @@ running=$(ps h -C "$me" | grep -wv $$ | wc -l);
 time=4
 bias=0
 
+min="0.5"
+max="5"
+light=$(light)
+diff=$(echo "scale=2; d = $light * 0.1; if (d < $min) $min else if (d > $max) $max else d" | bc)
+
 if [[ "$1" == "lower" ]]
 then
-    light -U 5
+    light -U "$diff"
 elif [[ "$1" == "raise" ]]
 then
-    light -A 5
+    light -A "$diff"
 fi
 
 light=$(light)

--- a/volumectl
+++ b/volumectl
@@ -3,13 +3,12 @@
 if [ "z$VOLUME_DEBUG" != "z" ]; then
     set -x
 fi
-
 function _current() {
-  CURRENT=$(pamixer --get-volume)
+  CURRENT=$(pamixer --get-volume --sink $SELECTED_SINK_N)
 }
 function _is_muted() {
 
-  OUT_MUTED=$(if $(pamixer --get-mute) == false; then echo yes; else echo no; fi)
+  OUT_MUTED=$(if $(pamixer --get-mute --sink $SELECTED_SINK_N) == false; then echo yes; else echo no; fi)
 
   IN_MUTED=$(pactl list sources|\
     grep '^[[:space:]]\(Mute\|Name\)'|\
@@ -20,12 +19,16 @@ function _is_muted() {
 
 AMOUNT="5%"
 TIME=1
+DEFAULT_SINK=$(pactl info | grep "Default Sink: "| awk -F": " '{print $2}')
+RUNNING_SINK=$(pactl list short sinks | grep RUNNING | cut -f 2 | head -n 1)
+SELECTED_SINK=${RUNNING_SINK:-$DEFAULT_SINK}
+SELECTED_SINK_N=$(pactl list short sinks | grep $SELECTED_SINK | cut -f1)
 DEF_SOURCE=$(pactl info | grep "Default Source: "| awk -F": " '{print $2}')
 
 function _maybe_unmute() {
   _is_muted
   if [[ "$OUT_MUTED" = "yes" ]]; then
-    pactl set-sink-mute @DEFAULT_SINK@ false
+    pactl set-sink-mute $SELECTED_SINK false
   fi
 }
 
@@ -33,17 +36,17 @@ function _raise() {
   _maybe_unmute
   _current
   if [ ${CURRENT} -lt 100 ]; then
-      pactl set-sink-volume @DEFAULT_SINK@ "+${AMOUNT}"
+      pactl set-sink-volume $SELECTED_SINK "+${AMOUNT}"
   fi
 }
 
 function _lower() {
   _maybe_unmute
-  pactl set-sink-volume @DEFAULT_SINK@ "-${AMOUNT}"
+  pactl set-sink-volume $SELECTED_SINK "-${AMOUNT}"
 }
 
 function _toggle_out_mute() {
-  pactl set-sink-mute @DEFAULT_SINK@ toggle
+  pactl set-sink-mute $SELECTED_SINK toggle
 }
 
 function _toggle_in_mute() {
@@ -106,7 +109,7 @@ function toggle_in_mute() {
 function help() {
   cat <<EOH
 $0 [COMMAND]
-Control the volume of the default sink and displays the current outcome.
+Control the volume of the running sink and displays the current outcome.
 May also mute/unmute all the microphone inputs.
 
 COMMAND:


### PR DESCRIPTION
I would like to contribute some changes that I made to avizo that maybe somebody else could find useful as well.

There are two changes:

1. lightctl to increase/decrease the backlight by 10% of the current backlight value, allowing much more granular control in low-light conditions. The change is actually limited to between 0.5 and 5, avoid changing the backlight too fast or too slow. The reasoning is that when in dark room with the default 5% increase/decrease, I often found my screen being either too bright or too dark. It was very difficult to control, even though the hardware actually supports very granular control in my case.
2. volumectl to track the currently playing sink instead of always tracking the default one. Applies to all operations, such as raise, lower, or mute. The reasoning is that I often find myself unable to control the volume of my headphones.