### PR TITLE
Fix bug in loading of first image after service start

### DIFF
--- a/src/avizo_service.vala
+++ b/src/avizo_service.vala
@@ -186,7 +186,7 @@ public class AvizoService : GLib.Object
 	};
 
 	public string image_path { get; set; default = ""; }
-	public string image_resource { get; set; default = "volume_muted"; }
+	public string image_resource { get; set; default = ""; }
 	public double progress { get; set; default = 0.0; }
 	public int width { get; set; default = 248; }
 	public int height { get; set; default = 232; }


### PR DESCRIPTION
When avizo-client is called with --image-path, it is overriden by the default image_resource = "volume_muted", until another another image is requested.

This bug was introduced in 5f41024730f74076ec9324551cc650b845d026bc.