### PR TITLE
Fix GtkLayerShell set_keyboard_interactivity deprecation warning

### DIFF
--- a/src/avizo_service.vala
+++ b/src/avizo_service.vala
@@ -253,7 +253,11 @@ public class AvizoService : GLib.Object
 		GtkLayerShell.set_layer(window, GtkLayerShell.Layer.OVERLAY);
 		GtkLayerShell.set_anchor(window, GtkLayerShell.Edge.TOP, true);
 		GtkLayerShell.set_exclusive_zone(window, -1);
+#if HAVE_LATEST_GTK_LAYER_SHELL
+		GtkLayerShell.set_keyboard_mode(window, GtkLayerShell.KeyboardMode.NONE);
+#else
 		GtkLayerShell.set_keyboard_interactivity(window, false);
+#endif
 
 		return window;
 	}

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,6 +30,11 @@ sources_client = [
   app_sources_client
 ]
 
+gtk_layer_shell = dependency('gtk-layer-shell-0', fallback: ['gtk-layer-shell'])
+if gtk_layer_shell.version() >= '0.6.0'
+  add_project_arguments('-D', 'HAVE_LATEST_GTK_LAYER_SHELL', language: 'vala')
+endif
+
 executable('avizo-service',
   sources_service,
   vala_args: ['--pkg=GtkLayerShell-0.1'],


### PR DESCRIPTION
GtkLayerShell version 0.6.0 and above have deprecated the `set_keyboard_interactivity` function.

This PR adds a compile time check for the version of GtkLayerShell and uses the right function accordingly.
