### PR TITLE
volumectl to optionally choose the currently playing sink

### DIFF
--- a/volumectl
+++ b/volumectl
@@ -24,6 +24,9 @@
 #   -b               Allow volume to go above 100% (boost).
 #   -D <device-id>   Choose a different sink (output) or source (input) than
 #                      the default (see pamixer --list-sinks and --list-sources).
+#   -p               Choose the currently playing sink instead of the default.
+#                      In case of multiple playing sinks, it will choose the
+#                      first playing  sink as reported by 'pactl'.
 #   -g <gamma>       Increase/decrease using gamma correction (e.g. 2.2).
 #   -m               Control the source (mic) instead of sink (output).
 #   -u               Unmute when changing the volume (+|-|=).
@@ -58,14 +61,16 @@ is_integer() {
 all_flag=false
 dev=
 dev_type='sink'
+use_playing=
 opts=
 unmute_opt=
 optind=1
-while getopts ':abD:g:muh' OPT; do
+while getopts ':abD:pg:muh' OPT; do
 	case "$OPT" in
 		a) all_flag=true;;
 		b) opts="$opts --allow-boost";;
 		D) dev=$OPTARG;;
+		p) use_playing=true;;
 		g) opts="$opts --gamma=$OPTARG";;
 		m) dev_type='source';;
 		u) unmute_opt='--unmute';;
@@ -115,6 +120,9 @@ dev_opt=
 if [ "$dev_type" = 'source' ] && [ -z "$dev" ]; then
 	dev_opt='--default-source'
 elif [ "$dev" ]; then
+	dev_opt="--$dev_type=$dev"
+elif [ "$dev_type" = 'sink' ] && [ "$use_playing" ]; then
+	dev=$(pactl list short sinks | grep RUNNING | cut -f 2 | head -n 1)
 	dev_opt="--$dev_type=$dev"
 fi
 


### PR DESCRIPTION
Adds to `volumectl` the option `-p` to make it choose the currently playing sink instead of the default sink. Has no effect when used alongside `-D <device-id>` or when controlling the microphone with `-m`. Takes precedence over `-a` (using all devices).

The new option depends on `pactl`. The script `volumectl` does not currently depend on `pactl`, however, it used to depend on it before it being refactored recently.

Also, when there are multiple playing sinks, it simply chooses the first one as reported by `pactl` (which I believe is based on a static order of devices, and does not actually depend on which sink actually started playing first).

My pull request should not change any behavior when `-p` is not passed.

This pull request replaces https://github.com/misterdanb/avizo/pull/16.