### PR TITLE
Adds option to specify monitor

### DIFF
--- a/lightctl
+++ b/lightctl
@@ -17,6 +17,7 @@
 # Options:
 #   -e <exponent>   Change percentage curve to exponential (only for brightnessctl).
 #   -D <device>     Specify the device name.
+#   -M <monitornr>  Set monitor where notification will be shown.
 #   -d              Show dark theme friendly variant of the icon
 #   -h              Show this message and exit.
 #
@@ -49,11 +50,13 @@ exp=
 dev=
 optind=1
 dark=0
-while getopts ':e:D:h:d' OPT; do
+monitor=-1
+while getopts ':e:D:h:M:d' OPT; do
 	case "$OPT" in
 		e) exp=$OPTARG;;
 		D) dev=$OPTARG;;
 		h) help; exit 0;;
+		M) monitor="$OPTARG";;
 		d) dark=1;;
 		\?) case "$OPTARG" in
 		    	[0-9]*) break;;
@@ -133,4 +136,4 @@ fi
 
 progress=$(echo "$light" | awk '{ printf "%.2f", $1 / 100 }')
 
-avizo-client --image-resource="$image" --progress="$progress"
+avizo-client --image-resource="$image" --progress="$progress" --monitor="$monitor"

--- a/src/avizo_client.vala
+++ b/src/avizo_client.vala
@@ -22,6 +22,7 @@ interface AvizoService : GLib.Object
 	public abstract Gdk.RGBA border_color { owned get; set; }
 	public abstract Gdk.RGBA bar_fg_color { owned get; set; }
 	public abstract Gdk.RGBA bar_bg_color { owned get; set; }
+	public abstract int monitor { owned get; set; }
 
 	public abstract void show(double seconds) throws DBusError, IOError;
 }
@@ -52,6 +53,7 @@ public class AvizoClient : GLib.Application
 	private static string _border_color = "";
 	private static string _bar_fg_color = "";
 	private static string _bar_bg_color = "";
+	private static int _monitor = -1;
 
 	private static double _time = 5.0;
 
@@ -80,6 +82,7 @@ public class AvizoClient : GLib.Application
 		{ "bar-fg-color", 0, 0, OptionArg.STRING, ref _bar_fg_color, "Sets the color of the filled bar blocks in format rgba([0, 255], [0, 255], [0, 255], [0, 1])", "STRING" },
 		{ "bar-bg-color", 0, 0, OptionArg.STRING, ref _bar_bg_color, "Sets the color of the unfilled bar blocks in format rgba([0, 255], [0, 255], [0, 255], [0, 1])", "STRING" },
 		{ "time", 0, 0, OptionArg.DOUBLE, ref _time, "Sets the time to show the notification, default is 5", "DOUBLE" },
+		{ "monitor", 0, 0, OptionArg.INT, ref _monitor, "Sets the monitor to show the notification on, default is all", "INT" },
 		{ null }
 	};
 
@@ -188,6 +191,7 @@ public class AvizoClient : GLib.Application
 
 		_service.fade_in = _fade_in;
 		_service.fade_out = _fade_out;
+		_service.monitor = _monitor;
 
 		if (_background != "")
 		{

--- a/volumectl
+++ b/volumectl
@@ -29,6 +29,7 @@
 #                      it will choose the first one as reported by pactl/pamixer.
 #   -g <gamma>       Increase/decrease using gamma correction (e.g. 2.2).
 #   -m               Control the source (mic) instead of sink (output).
+#   -M <monitornr>   Set monitor where notification will be shown.
 #   -u               Unmute when changing the volume (+|-|=).
 #   -d               Show dark theme friendly variant of the icon
 #   -h               Show this message and exit.
@@ -75,7 +76,8 @@ opts=
 unmute_opt=
 optind=1
 dark=0
-while getopts ':adbD:pg:muh' OPT; do
+monitor=-1
+while getopts ':adbD:pg:mM:uh' OPT; do
 	case "$OPT" in
 		a) all_flag=true;;
 		b) opts="$opts --allow-boost";;
@@ -83,6 +85,7 @@ while getopts ':adbD:pg:muh' OPT; do
 		p) use_playing=true;;
 		g) opts="$opts --gamma=$OPTARG";;
 		m) dev_type='source';;
+		M) monitor="$OPTARG";;
 		u) unmute_opt='--unmute';;
 		d) dark=1;;
 		h) help; exit 0;;
@@ -181,4 +184,4 @@ if [ "$dark" -eq 1 ]; then
 fi
 
 progress=$(echo "$volume" | awk '{ printf "%.2f", ($1 > 100 ? 1 : $1 / 100) }')
-avizo-client --image-resource="$image" --progress="$progress"
+avizo-client --image-resource="$image" --progress="$progress" --monitor="$monitor"


### PR DESCRIPTION
This adds the option to specify a monitor, which could be used to only display the notification on the focused monitor, for example like this with hyprland: 
```bash
volumectl -M $(hyprctl activeworkspace | awk '/monitorID/{print $2}' | head -n 1) -u up
```
and defaults to all as before