### PR TITLE
Catch Errors + Remove Shellcheck Warning

### DIFF
--- a/lightctl
+++ b/lightctl
@@ -29,7 +29,7 @@ set -eu
 PROGNAME='lightctl'
 
 help() {
-	local tag='---help---'
+	tag='---help---'
 	sed -n "/^#$tag/,/^#$tag/{/^#$tag/d; s/^# \\?//; s|\$0|$0|; p}" "$0"
 }
 
@@ -96,7 +96,7 @@ esac
 if command -v brightnessctl >/dev/null; then
 	prog='brightnessctl'
 	opts="${dev:+-d $dev}"
-	out=$(brightnessctl $opts ${exp:+-e$exp} -m set "${value}%${cmd}")
+	out=$(brightnessctl "$opts" ${exp:+-e$exp} -m set "${value}%${cmd}")
 	light=$(printf '%s\n' "$out" | cut -d, -f4)
 	light=${light%\%}
 
@@ -104,12 +104,12 @@ elif command -v light >/dev/null; then
 	prog='light'
 	opts="${dev:+-s $dev}"
 	case "$cmd" in
-		+) light $opts -A "$value";;
-		-) light $opts -U "$value";;
-		=) light $opts -S "$value";;
+		+) light "$opts" -A "$value";;
+		-) light "$opts" -U "$value";;
+		=) light "$opts" -S "$value";;
 	esac
 
-	light=$(light $opts -G)
+	light=$(light "$opts" -G)
 else
 	die 'command not found: brightnessctl or light'
 fi
@@ -119,7 +119,7 @@ if ! is_integer "$light" && ! is_float "$light"; then
 fi
 
 if is_float "$light"; then
-    light=${light/.*}
+    light=$(echo "$light" | awk -F '.' '{print $1}')
 fi
 
 if [ "$light" -le 33 ]; then

--- a/src/avizo_client.vala
+++ b/src/avizo_client.vala
@@ -91,9 +91,16 @@ public class AvizoClient : GLib.Application
 		Object(application_id: "org.danb.avizo.client",
 		       flags: ApplicationFlags.HANDLES_COMMAND_LINE);
 
-		_service = Bus.get_proxy_sync(BusType.SESSION,
-		                              "org.danb.avizo.service",
-		                              "/org/danb/avizo/service");
+		try
+		{
+			_service = Bus.get_proxy_sync(BusType.SESSION,
+			                              "org.danb.avizo.service",
+			                              "/org/danb/avizo/service");
+		}
+		catch (IOError e)
+		{
+			stderr.printf(@"avizo: $(e.message)\n");
+		}
 	}
 
 	public override int command_line(ApplicationCommandLine command_line)
@@ -168,62 +175,75 @@ public class AvizoClient : GLib.Application
 			return 0;
 		}
 
-		if (_image_path != "")
+		try
 		{
-			_service.image_path = Filename.canonicalize(_image_path, _image_base_dir);
-		}
-		else
-		{
-			_service.image_resource = _image_resource;
-		}
-
-		_service.image_opacity = _image_opacity;
-		_service.progress = _progress;
-		_service.width = _width;
-		_service.height = _height;
-		_service.padding = _padding;
-		_service.y_offset = _y_offset;
-		_service.border_radius = _border_radius;
-		_service.border_width = _border_width;
-		_service.block_height = _block_height;
-		_service.block_spacing = _block_spacing;
-		_service.block_count = _block_count;
-
-		_service.fade_in = _fade_in;
-		_service.fade_out = _fade_out;
-		_service.monitor = _monitor;
-
-		if (_background != "")
-		{
-			var color = parse_rgba(_background);
-			_service.background = color;
-
-			if (_bar_bg_color == "")
+			if (_image_path != "")
 			{
-				var bar_color = color.copy();
-				bar_color.red /= 1.5;
-				bar_color.green /= 1.5;
-				bar_color.blue /= 1.5;
-				_service.bar_bg_color = bar_color;
+				_service.image_path = Filename.canonicalize(_image_path, _image_base_dir);
 			}
-		}
+			else
+			{
+				_service.image_resource = _image_resource;
+			}
 
-		if (_border_color != "")
+			_service.image_opacity = _image_opacity;
+			_service.progress = _progress;
+			_service.width = _width;
+			_service.height = _height;
+			_service.padding = _padding;
+			_service.y_offset = _y_offset;
+			_service.border_radius = _border_radius;
+			_service.border_width = _border_width;
+			_service.block_height = _block_height;
+			_service.block_spacing = _block_spacing;
+			_service.block_count = _block_count;
+
+			_service.fade_in = _fade_in;
+			_service.fade_out = _fade_out;
+			_service.monitor = _monitor;
+
+			if (_background != "")
+			{
+				var color = parse_rgba(_background);
+				_service.background = color;
+
+				if (_bar_bg_color == "")
+				{
+					var bar_color = color.copy();
+					bar_color.red /= 1.5;
+					bar_color.green /= 1.5;
+					bar_color.blue /= 1.5;
+					_service.bar_bg_color = bar_color;
+				}
+			}
+
+			if (_border_color != "")
+			{
+				_service.border_color = parse_rgba(_border_color);
+			}
+
+			if (_bar_bg_color != "")
+			{
+				_service.bar_bg_color = parse_rgba(_bar_bg_color);
+			}
+
+			if (_bar_fg_color != "")
+			{
+				_service.bar_fg_color = parse_rgba(_bar_fg_color);
+			}
+
+			_service.show(_time);
+		}
+		catch (DBusError e)
 		{
-			_service.border_color = parse_rgba(_border_color);
+			stderr.printf(@"avizo: avizo-service is not running\n");
+			return 1;
 		}
-
-		if (_bar_bg_color != "")
+		catch (IOError e)
 		{
-			_service.bar_bg_color = parse_rgba(_bar_bg_color);
+			stderr.printf(@"avizo: $(e.message)\n");
+			return 1;
 		}
-
-		if (_bar_fg_color != "")
-		{
-			_service.bar_fg_color = parse_rgba(_bar_fg_color);
-		}
-
-		_service.show(_time);
 
 		return 0;
 	}

--- a/volumectl
+++ b/volumectl
@@ -46,7 +46,7 @@ fi
 PROGNAME='volumectl'
 
 help() {
-	local tag='---help---'
+	tag='---help---'
 	sed -n "/^#$tag/,/^#$tag/{/^#$tag/d; s/^# \\?//; s|\$0|$0|; p}" "$0"
 }
 
@@ -61,9 +61,9 @@ is_integer() {
 
 playing_dev_id() {
 	if command -v pactl >/dev/null; then
-		pactl list short ${1}s | grep RUNNING | grep -m1 -o '^[0-9]\+'
+		pactl list short "${1}s" | grep RUNNING | grep -m1 -o '^[0-9]\+'
 	else  # this works since pamixer 1.6
-		pamixer --list-${1}s | grep '"Running"' | grep -m1 -o '^[0-9]\+'
+		pamixer --list-"${1}s" | grep '"Running"' | grep -m1 -o '^[0-9]\+'
 	fi
 }
 
@@ -140,11 +140,11 @@ elif $use_playing && id=$(playing_dev_id "$dev_type"); then
 fi
 
 
-pamixer $dev_opt $opts $unmute_opt $cmd_opt
+pamixer "$dev_opt" "$opts" "$unmute_opt" "$cmd_opt"
 
 # Note: pamixer returns 1 when muted or volume is 0
-muted=$(pamixer $dev_opt --get-mute || :)
-volume=$(pamixer $dev_opt --get-volume || :)
+muted=$(pamixer "$dev_opt" --get-mute || :)
+volume=$(pamixer "$dev_opt" --get-volume || :)
 
 if ! is_integer "$volume"; then
 	die "pamixer returned invalid volume level: '$volume'"
@@ -154,7 +154,7 @@ if $all_flag; then
 	[ "$muted" = 'true' ] && mute_opt='--mute' || mute_opt='--unmute'
 
 	for id in $(pamixer --list-${dev_type}s | grep -o '^[0-9]\+'); do
-		pamixer --$dev_type=$id $mute_opt || :
+		pamixer --$dev_type="$id" "$mute_opt" || :
 	done
 fi
 


### PR DESCRIPTION
Hey,
this fixes https://github.com/misterdanb/avizo/issues/48 by replacing it with an identical awk command
(the suggested fix `light=${light%.*}` retains everything before the last dot e.g. abc.def.ghi -> abc.def, while the original and the awk command remove everything after the first dot abc.def.ghi -> abc), and removes some other warnings of shellcheck, to prevent globbing and word splitting. 
Also, local isn't defined by posix, which is why I removed it, 
and set -o pipefail was added to posix, so I kept that there though shellcheck still warns on that one

Additionally added a specific error message, like in https://github.com/misterdanb/avizo/issues/10,  when avizo-service is not running (even though only the show function throws the error, I think it reads cleaner around the whole settings for the service), as well as two other uncaught errors valac complained about