### PR TITLE
fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Adjust (display) brightness and show Avizo notification.
 
 * POSIX-sh compatible shell (e.g. Busybox ash, dash, ZSH, bash, …)
 * common \*nix userland (BSD, Busybox or GNU)
-* [brightnessctl](https://github.com/Hummer12007/brightnessctl) or [light](https://github.com/haikarainen/light)
+* [brightnessctl](https://github.com/Hummer12007/brightnessctl) or [light](https://gitlab.com/dpeukert/light)
 
 
 ## Sway config


### PR DESCRIPTION
The original link 404s. I _think_ I got the right project and it looks alive, or at least it's also linked on the [aur](https://aur.archlinux.org/packages/light) and the discussion there reflects the move

An alternative older fork that retains history might be https://github.com/klaxalk/light, and you can see for example [here](https://github.com/MarkusVolk/meta-wayland/blob/master/recipes-extended/light/light_git.bb) that a recent commit from the old repo is indeed present in the fork as well

Or  maybe, if the project is dead, it can just be removed from the readme here?